### PR TITLE
Allow running scripts directly by name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /.tox/
 /.hg/
 /script/
+.vscode/

--- a/README.rst
+++ b/README.rst
@@ -28,3 +28,10 @@ OK, now you can run the following command from the console::
     $ run dump
 
 That's all :) Of course this is not the rocket science, but I found that this simple script launcher saved me a lot of time.
+
+### Note
+In order to be able to run any script from any package in the project, please create a `run.ini` file in project root and have this content:
+```
+[global]
+search_path=
+```

--- a/run.ini
+++ b/run.ini
@@ -1,0 +1,2 @@
+[global]
+search_path=

--- a/run.ini
+++ b/run.ini
@@ -1,2 +1,0 @@
-[global]
-search_path=

--- a/run.ini.sample
+++ b/run.ini.sample
@@ -1,0 +1,2 @@
+[global]
+search_path=

--- a/runscript/cli.py
+++ b/runscript/cli.py
@@ -1,13 +1,14 @@
 import os
-from argparse import ArgumentParser
-import logging
 import sys 
 import imp
+import logging
+
 try:
     from ConfigParser import RawConfigParser, NoOptionError
 except ImportError:
     from configparser import RawConfigParser, NoOptionError
-import sys
+
+from argparse import ArgumentParser
 from traceback import format_exception
 from setproctitle import setproctitle
 
@@ -116,7 +117,12 @@ def process_command_line():
         imp_path = '%s.%s' % (path, action_name)
         if module_is_importable(imp_path):
             action_mod = __import__(imp_path, None, None, ['foo'])
-
+    else:
+        # If search path is blank, try to invoke 
+        # script directly, without namespaces
+        if module_is_importable(action_name):
+            action_mod = __import__(action_name, None, None, ['foo'])
+            
     if action_mod is None:
         sys.stderr.write('Could not find the package to import %s module\n' % action_name)
         sys.exit(1)

--- a/runscript/cli.py
+++ b/runscript/cli.py
@@ -1,5 +1,5 @@
 import os
-import sys 
+import sys
 import imp
 import logging
 
@@ -15,7 +15,8 @@ from setproctitle import setproctitle
 from runscript.lock import assert_lock
 
 
-logger = logging.getLogger('runscript.cli')
+logger = logging.getLogger("runscript.cli")
+
 
 def setup_logging(action, level, clear_handlers=False):
     root = logging.getLogger()
@@ -31,7 +32,7 @@ def setup_logging(action, level, clear_handlers=False):
 
 
 def module_is_importable(path):
-    mod_names = path.split('.')
+    mod_names = path.split(".")
     path = None
     for mod_name in mod_names:
         try:
@@ -44,19 +45,19 @@ def module_is_importable(path):
 
 
 def normalize_config_value(section, name, value):
-    if section == 'global' and name == 'search_path':
-        return [x.strip() for x in value.split(',')]
+    if section == "global" and name == "search_path":
+        return [x.strip() for x in value.split(",")]
     else:
         return value
 
 
 def load_config():
     cur_dir = os.getcwd()
-    config_path = os.path.join(cur_dir, 'run.ini')
+    config_path = os.path.join(cur_dir, "run.ini")
 
     config = {
-        'global': {
-            'search_path': ['grab.script', 'script'],
+        "global": {
+            "search_path": ["grab.script", "script"],
         },
     }
 
@@ -70,13 +71,25 @@ def load_config():
                 config[section][key] = normalize_config_value(section, key, val)
 
     return config
-    
+
 
 def custom_excepthook(etype, evalue, etb):
-    logging.fatal('\n'.join(format_exception(etype, evalue, etb)))
+    logging.fatal("\n".join(format_exception(etype, evalue, etb)))
 
 
-def process_command_line():
+def setup_arg_parser():
+    parser = ArgumentParser()
+    parser.add_argument("action", type=str)
+    parser.add_argument("--logging-level", default="debug")
+    parser.add_argument("--lock-key")
+    # parser.add_argument('--ignore-lock', action='store_true', default=False)
+    parser.add_argument("--env", type=str)
+    parser.add_argument("--profile", action="store_true", default=False)
+
+    return parser
+
+
+def global_setup(args):
     # Use custom excepthook that prints traceback via logging system
     # using FATAL level
     sys.excepthook = custom_excepthook
@@ -85,86 +98,86 @@ def process_command_line():
     cur_dir = os.path.realpath(os.getcwd())
     sys.path.insert(0, cur_dir)
 
-    parser = ArgumentParser()
-    parser.add_argument('action', type=str)
-    parser.add_argument('--logging-level', default='debug')
-    parser.add_argument('--lock-key')
-    #parser.add_argument('--ignore-lock', action='store_true', default=False)
-    parser.add_argument('--env', type=str)
-    parser.add_argument('--profile', action='store_true', default=False)
-
-    args, trash = parser.parse_known_args()
-
-    config = load_config()
     logging_level = getattr(logging, args.logging_level.upper())
     setup_logging(args.action, logging_level, clear_handlers=True)
 
-    if config['global'].get('django_settings_module'):
-        os.environ['DJANGO_SETTINGS_MODULE'] = config['global']['django_settings_module']
+
+def config_django_settings(args, config):
+    if config["global"].get("django_settings_module"):
+        os.environ["DJANGO_SETTINGS_MODULE"] = config["global"]["django_settings_module"]
 
         # Disable django DEBUG feature to prevent memory leaks
+        import django
         from django.conf import settings
+
         settings.DEBUG = False
 
-        import django
         django.setup()
 
+
+def setup_import_paths(args, config):
     # Setup action handler
     action_name = args.action
     action_mod = None
 
-    for path in config['global']['search_path']:
-        imp_path = '%s.%s' % (path, action_name)
+    for path in config["global"]["search_path"]:
+        imp_path = "%s.%s" % (path, action_name)
         if module_is_importable(imp_path):
-            action_mod = __import__(imp_path, None, None, ['foo'])
+            action_mod = __import__(imp_path, None, None, ["foo"])
     else:
-        # If search path is blank, try to invoke 
+        # If search path is blank, try to invoke
         # script directly, without namespaces
         if module_is_importable(action_name):
-            action_mod = __import__(action_name, None, None, ['foo'])
-            
+            action_mod = __import__(action_name, None, None, ["foo"])
+
     if action_mod is None:
-        sys.stderr.write('Could not find the package to import %s module\n' % action_name)
+        sys.stderr.write(
+            "Could not find the package to import %s module\n" % action_name
+        )
         sys.exit(1)
 
-    if hasattr(action_mod, 'setup_arg_parser'):
+    if hasattr(action_mod, "setup_arg_parser"):
         action_mod.setup_arg_parser(parser)
     args_obj, trash = parser.parse_known_args()
 
-    # Update proc title
-    if hasattr(action_mod, 'get_proc_title'):
-        setproctitle(action_mod.get_proc_title(args_obj))
-    else:
-        setproctitle('run_%s' % args.action)
-
-
     args = vars(args_obj)
 
-    for key, val in config.get('script:%s' % action_name, {}).items():
+    for key, val in config.get("script:%s" % action_name, {}).items():
         args[key] = val
 
-    if hasattr(action_mod, 'get_lock_key'):
+    # Update proc title
+    if hasattr(action_mod, "get_proc_title"):
+        setproctitle(action_mod.get_proc_title(args_obj))
+    else:
+        setproctitle("run_%s" % args.action)
+
+    return action_mod
+
+
+def setup_lock_key(action_mod, args, config):
+    if hasattr(action_mod, "get_lock_key"):
         lock_key = action_mod.get_lock_key(**args)
     else:
-        lock_key = args['lock_key']
+        lock_key = args["lock_key"]
 
     if lock_key is not None:
-        lock_path = 'var/run/%s.lock' % lock_key
-        logging.debug('Trying to lock file: {}'.format(lock_path))
+        lock_path = "var/run/%s.lock" % lock_key
+        logging.debug("Trying to lock file: {}".format(lock_path))
         assert_lock(lock_path)
 
-    if args['profile']:
+
+def setup_profile(action_mod, args, config):
+    if args["profile"]:
         import cProfile
         import pyprof2calltree
         import pstats
 
-        profile_file = 'var/%s.prof' % action_name
-        profile_tree_file = 'var/%s.prof.out' % action_name
+        profile_file = "var/%s.prof" % action_name
+        profile_tree_file = "var/%s.prof.out" % action_name
 
         prof = cProfile.Profile()
         try:
-            prof.runctx('action_mod.main(**args)',
-                        globals(), locals())
+            prof.runctx("action_mod.main(**args)", globals(), locals())
         finally:
             stats = pstats.Stats(prof)
             stats.strip_dirs()
@@ -173,5 +186,18 @@ def process_command_line():
         action_mod.main(**args)
 
 
-if __name__ == '__main__':
+def process_command_line():
+    parser = setup_arg_parser()
+    args, trash = parser.parse_known_args()
+    config = load_config()
+
+    # Configs
+    global_setup(args)
+    config_django_settings(args, config)
+    action_mod = setup_import_paths(args, config)
+    setup_lock_key(action_mod, args, config)
+    setup_profile(action_mod, args, config)
+
+
+if __name__ == "__main__":
     process_command_line()

--- a/runscript/cli.py
+++ b/runscript/cli.py
@@ -70,6 +70,9 @@ def load_config():
             for key, val in parser.items(section):
                 config[section][key] = normalize_config_value(section, key, val)
 
+    # Remove empty paths if any
+    config['global']['search_path'] = list(filter(lambda x: len(x) > 0, config['global']['search_path']))
+
     return config
 
 

--- a/runscript/cli.py
+++ b/runscript/cli.py
@@ -15,7 +15,7 @@ from setproctitle import setproctitle
 from runscript.lock import assert_lock
 
 
-logger = logging.getLogger("runscript.cli")
+logger = logging.getLogger('runscript.cli')
 
 
 def setup_logging(action, level, clear_handlers=False):
@@ -32,7 +32,7 @@ def setup_logging(action, level, clear_handlers=False):
 
 
 def module_is_importable(path):
-    mod_names = path.split(".")
+    mod_names = path.split('.')
     path = None
     for mod_name in mod_names:
         try:
@@ -45,19 +45,19 @@ def module_is_importable(path):
 
 
 def normalize_config_value(section, name, value):
-    if section == "global" and name == "search_path":
-        return [x.strip() for x in value.split(",")]
+    if section == 'global' and name == 'search_path':
+        return [x.strip() for x in value.split(',')]
     else:
         return value
 
 
 def load_config():
     cur_dir = os.getcwd()
-    config_path = os.path.join(cur_dir, "run.ini")
+    config_path = os.path.join(cur_dir, 'run.ini')
 
     config = {
-        "global": {
-            "search_path": ["grab.script", "script"],
+        'global': {
+            'search_path': ['grab.script', 'script'],
         },
     }
 
@@ -74,17 +74,17 @@ def load_config():
 
 
 def custom_excepthook(etype, evalue, etb):
-    logging.fatal("\n".join(format_exception(etype, evalue, etb)))
+    logging.fatal('\n'.join(format_exception(etype, evalue, etb)))
 
 
 def setup_arg_parser():
     parser = ArgumentParser()
-    parser.add_argument("action", type=str)
-    parser.add_argument("--logging-level", default="debug")
-    parser.add_argument("--lock-key")
+    parser.add_argument('action', type=str)
+    parser.add_argument('--logging-level', default='debug')
+    parser.add_argument('--lock-key')
     # parser.add_argument('--ignore-lock', action='store_true', default=False)
-    parser.add_argument("--env", type=str)
-    parser.add_argument("--profile", action="store_true", default=False)
+    parser.add_argument('--env', type=str)
+    parser.add_argument('--profile', action='store_true', default=False)
 
     return parser
 
@@ -103,10 +103,8 @@ def global_setup(args):
 
 
 def config_django_settings(args, config):
-    if config["global"].get("django_settings_module"):
-        os.environ["DJANGO_SETTINGS_MODULE"] = config["global"][
-            "django_settings_module"
-        ]
+    if config['global'].get('django_settings_module'):
+        os.environ['DJANGO_SETTINGS_MODULE'] = config['global']['django_settings_module']
 
         # Disable django DEBUG feature to prevent memory leaks
         import django
@@ -122,19 +120,19 @@ def setup_import_paths(args, config, parser=None):
     action_name = args.action
     action_mod = None
 
-    for path in config["global"]["search_path"]:
-        imp_path = "%s.%s" % (path, action_name)
+    for path in config['global']['search_path']:
+        imp_path = '%s.%s' % (path, action_name)
         if module_is_importable(imp_path):
-            action_mod = __import__(imp_path, None, None, ["foo"])
+            action_mod = __import__(imp_path, None, None, ['foo'])
     else:
         # If search path is blank, try to invoke
         # script directly, without namespaces
         if module_is_importable(action_name):
-            action_mod = __import__(action_name, None, None, ["foo"])
+            action_mod = __import__(action_name, None, None, ['foo'])
 
     if action_mod is None:
         sys.stderr.write(
-            "Could not find the package to import %s module\n" % action_name
+            'Could not find the package to import %s module\n' % action_name
         )
         sys.exit(1)
 
@@ -154,43 +152,43 @@ def process_command_line():
     # Setup action handler
     action_name = args.action
 
-    if hasattr(action_mod, "setup_arg_parser"):
+    if hasattr(action_mod, 'setup_arg_parser'):
         action_mod.setup_arg_parser(parser)
 
     args_obj, trash = parser.parse_known_args()
 
     # Update proc title
-    if hasattr(action_mod, "get_proc_title"):
+    if hasattr(action_mod, 'get_proc_title'):
         setproctitle(action_mod.get_proc_title(args_obj))
     else:
-        setproctitle("run_%s" % args.action)
+        setproctitle('run_%s' % args.action)
 
     args = vars(args_obj)
 
-    for key, val in config.get("script:%s" % action_name, {}).items():
+    for key, val in config.get('script:%s' % action_name, {}).items():
         args[key] = val
 
-    if hasattr(action_mod, "get_lock_key"):
+    if hasattr(action_mod, 'get_lock_key'):
         lock_key = action_mod.get_lock_key(**args)
     else:
-        lock_key = args["lock_key"]
+        lock_key = args['lock_key']
 
     if lock_key is not None:
-        lock_path = "var/run/%s.lock" % lock_key
-        logging.debug("Trying to lock file: {}".format(lock_path))
+        lock_path = 'var/run/%s.lock' % lock_key
+        logging.debug('Trying to lock file: {}'.format(lock_path))
         assert_lock(lock_path)
 
-    if args["profile"]:
+    if args['profile']:
         import cProfile
         import pyprof2calltree
         import pstats
 
-        profile_file = "var/%s.prof" % action_name
-        profile_tree_file = "var/%s.prof.out" % action_name
+        profile_file = 'var/%s.prof' % action_name
+        profile_tree_file = 'var/%s.prof.out' % action_name
 
         prof = cProfile.Profile()
         try:
-            prof.runctx("action_mod.main(**args)", globals(), locals())
+            prof.runctx('action_mod.main(**args)', globals(), locals())
         finally:
             stats = pstats.Stats(prof)
             stats.strip_dirs()
@@ -199,5 +197,5 @@ def process_command_line():
         action_mod.main(**args)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     process_command_line()


### PR DESCRIPTION
Previously, in order to be able to run a script, a script must be placed in `script` folder. With this PR, any script can be run with specified path as ` run v1.scripts.test.foo_bar`, so it doesn't need to be placed in `script` folder. 

To enable this feature, in project root, create a file `run.ini` and have this inside:
```
[global]
search_path=
```